### PR TITLE
tomek config

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,3 @@
+{
+    "extends": ["@salesforce/eslint-config-lwc/recommended"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ deploy-options.json
 # LWC Jest coverage reports
 coverage/
 
+# Salesforce security scanner logs
+scanner.html
+
 # Logs
 logs
 *.log
@@ -24,8 +27,9 @@ yarn-error.log*
 # Dependency directories
 node_modules/
 
-# Eslint cache
+# Tools cache
 .eslintcache
+.pmdCache
 
 # MacOS system files
 .DS_Store

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,7 @@
 # More information: https://prettier.io/docs/en/ignore.html
 #
 
+**/flows/**
 **/staticresources/**
 .localdevserver
 .sfdx

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,13 +1,19 @@
 {
-  "trailingComma": "none",
-  "overrides": [
-    {
-      "files": "**/lwc/**/*.html",
-      "options": { "parser": "lwc" }
-    },
-    {
-      "files": "*.{cmp,page,component}",
-      "options": { "parser": "html" }
-    }
-  ]
+    "trailingComma": "none",
+    "singleQuote": true,
+    "tabWidth": 4,
+    "bracketSameLine": true,
+    "printWidth": 120,
+    "htmlWhitespaceSensitivity" : "ignore",
+    "apexInsertFinalNewline" : false,
+    "overrides": [
+        {
+            "files": "**/lwc/**/*.html",
+            "options": { "parser": "lwc" }
+        },
+        {
+            "files": "*.{cmp,page,component}",
+            "options": { "parser": "html" }
+        }
+    ]
 }

--- a/package.json
+++ b/package.json
@@ -1,41 +1,44 @@
 {
-  "name": "salesforce-app",
-  "private": true,
-  "version": "1.0.0",
-  "description": "Salesforce App",
-  "scripts": {
-    "lint": "eslint **/{aura,lwc}/**",
-    "test": "npm run test:unit",
-    "test:unit": "sfdx-lwc-jest",
-    "test:unit:watch": "sfdx-lwc-jest --watch",
-    "test:unit:debug": "sfdx-lwc-jest --debug",
-    "test:unit:coverage": "sfdx-lwc-jest --coverage",
-    "prettier": "prettier --write \"**/*.{cls,cmp,component,css,html,js,json,md,page,trigger,xml,yaml,yml}\"",
-    "prettier:verify": "prettier --list-different \"**/*.{cls,cmp,component,css,html,js,json,md,page,trigger,xml,yaml,yml}\"",
-    "postinstall": "husky install",
-    "precommit": "lint-staged"
-  },
-  "devDependencies": {
-    "@lwc/eslint-plugin-lwc": "^1.1.2",
-    "@prettier/plugin-xml": "^2.0.1",
-    "@salesforce/eslint-config-lwc": "^3.2.3",
-    "@salesforce/eslint-plugin-aura": "^2.0.0",
-    "@salesforce/eslint-plugin-lightning": "^1.0.0",
-    "@salesforce/sfdx-lwc-jest": "^1.1.0",
-    "eslint": "^8.11.0",
-    "eslint-plugin-import": "^2.25.4",
-    "eslint-plugin-jest": "^26.1.2",
-    "husky": "^7.0.4",
-    "lint-staged": "^12.3.7",
-    "prettier": "2.8.8",
-    "prettier-plugin-apex": "1.13.0"
-  },
-  "lint-staged": {
-    "**/*.{cls,cmp,component,css,html,js,json,md,page,trigger,xml,yaml,yml}": [
-      "prettier --write"
-    ],
-    "**/{aura,lwc}/**": [
-      "eslint"
-    ]
-  }
+    "name": "salesforce-app",
+    "private": true,
+    "version": "1.0.0",
+    "description": "Salesforce App",
+    "scripts": {
+        "lint": "eslint **/{lwc,aura}/**/*.js",
+        "test": "npm run test:unit",
+        "test:unit": "sfdx-lwc-jest",
+        "test:unit:watch": "sfdx-lwc-jest --watch",
+        "test:unit:debug": "sfdx-lwc-jest --debug",
+        "test:unit:coverage": "sfdx-lwc-jest --coverage",
+        "prettier": "prettier --plugin=prettier-plugin-apex --write \"**/*.{cls,cmp,component,css,html,js,json,md,page,trigger,xml,yaml,yml}\"",
+        "prettier:verify": "prettier --list-different \"**/*.{cls,cmp,component,css,html,js,json,md,page,trigger,xml,yaml,yml}\"",
+        "postinstall": "husky install",
+        "precommit": "lint-staged",
+        "scanner": "sf scanner:run -t=./force-app -f=html -s=1 -c '!Documentation' -o scanner.html"
+    },
+    "devDependencies": {
+        "@lwc/eslint-plugin-lwc": "^1.6.3",
+        "@prettier/plugin-xml": "^3.2.0",
+        "@sa11y/jest": "^5.3.0",
+        "@salesforce/eslint-config-lwc": "^3.5.2",
+        "@salesforce/eslint-plugin-aura": "^2.1.0",
+        "@salesforce/eslint-plugin-lightning": "^1.0.0",
+        "@salesforce/sfdx-lwc-jest": "3.0.0",
+        "eslint": "^8.48.0",
+        "eslint-plugin-import": "^2.28.1",
+        "eslint-plugin-jest": "^27.2.3",
+        "husky": "^8.0.3",
+        "jest-canvas-mock": "^2.5.2",
+        "lint-staged": "^14.0.1",
+        "prettier": "^3.0.3",
+        "prettier-plugin-apex": "^2.0.1"
+    },
+    "lint-staged": {
+        "**/*.{cls,cmp,component,css,html,js,json,md,page,trigger,xml,yaml,yml}": [
+            "prettier --write"
+        ],
+        "**/{aura,lwc}/**": [
+            "eslint"
+        ]
+    }
 }


### PR DESCRIPTION
Here's NPM config from my side project. 

- Updated versions of many tools in package.json (so you'll have to run `npm install`)
- new command that (if you have [scanner ](https://forcedotcom.github.io/sfdx-scanner/) installed - it can be run just with `npm run scanner`)
- added prettier config (.prettierrc) about tabs vs spaces etc, max line length, curly braces in same or next line... the options you'd have to read up. Most are explained in https://github.com/dangmai/prettier-plugin-apex

1. Checkout this branch.
2. Run `npm install`
3. Run `npm run prettier`
4. It'll probably f*** up more files than you wanted and in the ways you didn't expect ;). That's why it's good to configure it to your liking.
5. You can revert the changes prettier did, tweak the config, run again
6. When happy - commit and accept the pull request

This is just my config, there is no right one. You can always <strike>steal from</strike> get inspired by SF repository, see what they have in https://github.com/trailheadapps/lwc-recipes/blob/main/.prettierrc, eslintrc, package.json...

I think default `npm install` includes "husky". Husky will run the command specified in "precommit" part of the package.json. So it'll silently run prettier and fix the files just as you're making next Git commit. If you don't want that and prefer to format them manually - comment out the line in `./husky/pre-commit`, put hash in front: `#npm run precommit`